### PR TITLE
refactor: replace String-based errors with structured variants

### DIFF
--- a/asn1/src/error.rs
+++ b/asn1/src/error.rs
@@ -4,32 +4,77 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
+    // Boolean errors
     #[error("invalid boolean")]
     InvalidBoolean,
-    #[error("invalid integer: {0}")]
-    InvalidInteger(String),
-    #[error("invalid object identifier: {0}")]
-    InvalidObjectIdentifier(String),
+
+    // Integer errors
+    #[error("INTEGER: no data")]
+    IntegerNoData,
+    #[error("INTEGER: value out of range for i64")]
+    IntegerOutOfRangeI64,
+    #[error("INTEGER: value out of range for u64")]
+    IntegerOutOfRangeU64,
     #[error("parse int error: {0}")]
     ParseInt(ParseIntError),
-    #[error("invalid bit string: {0}")]
-    InvalidBitString(String),
-    #[error("invalid utf-8 string: {0}")]
-    InvalidUTF8String(String),
-    #[error("invalid printable string: {0}")]
-    InvalidPrintableString(String),
-    #[error("invalid IA5 string: {0}")]
-    InvalidIA5String(String),
-    #[error("invalid UTC time: {0}")]
-    InvalidUTCTime(String),
-    #[error("invalid generalized time: {0}")]
-    InvalidGeneralizedTime(String),
-    #[error("invalid BMP string: {0}")]
-    InvalidBMPString(String),
+
+    // ObjectIdentifier errors
+    #[error("OBJECT IDENTIFIER: no data")]
+    ObjectIdentifierNoData,
+    #[error("OBJECT IDENTIFIER: incomplete encoding")]
+    ObjectIdentifierIncompleteEncoding,
+    #[error("OBJECT IDENTIFIER: too few components (need at least 2)")]
+    ObjectIdentifierTooFewComponents,
+    #[error("OBJECT IDENTIFIER: empty string")]
+    ObjectIdentifierEmptyString,
+    #[error("OBJECT IDENTIFIER: invalid component '{0}'")]
+    ObjectIdentifierInvalidComponent(String),
+
+    // BitString errors
+    #[error("BIT STRING: no data")]
+    BitStringNoData,
+    #[error("BIT STRING: unused bits {0} out of range (must be 0-7)")]
+    BitStringUnusedBitsOutOfRange(u8),
+
+    // String type errors
+    #[error("UTF8String: invalid UTF-8")]
+    Utf8StringInvalidUtf8,
+    #[error("PrintableString: invalid encoding")]
+    PrintableStringInvalidEncoding,
+    #[error("IA5String: invalid encoding")]
+    Ia5StringInvalidEncoding,
+
+    // Time errors
+    #[error("UTCTime: no data")]
+    UtcTimeNoData,
+    #[error("UTCTime: invalid format")]
+    UtcTimeInvalidFormat,
+    #[error("GeneralizedTime: no data")]
+    GeneralizedTimeNoData,
+    #[error("GeneralizedTime: invalid format")]
+    GeneralizedTimeInvalidFormat,
+
+    // BMPString errors
+    #[error("BMPString: odd byte length {0}")]
+    BmpStringOddLength(usize),
+    #[error("BMPString: invalid code point at position {position}: 0x{code_point:04X}")]
+    BmpStringInvalidCodePoint { position: usize, code_point: u16 },
+    #[error("BMPString: contains character outside BMP (requires surrogate pair)")]
+    BmpStringRequiresSurrogatePair,
+    #[error("BMPString: conversion to String failed")]
+    BmpStringConversionFailed,
+
+    // Context-specific errors
     #[error("invalid context-specific value: {slot}, {msg}")]
     InvalidContextSpecific { slot: u8, msg: String },
+
+    // DER errors
     #[error("invalid DER encoding: {0}")]
     FailedToDecodeDer(#[source] der::error::Error),
-    #[error("invalid element: {0}")]
-    InvalidElement(String),
+
+    // Element errors
+    #[error("element: cannot encode {0}")]
+    ElementCannotEncode(&'static str),
+    #[error("element: unimplemented type")]
+    ElementUnimplemented,
 }

--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -32,6 +32,9 @@ pub(crate) enum Error {
     #[error("PKIX types error: {0}")]
     PkixTypes(#[from] pkix_types::Error),
 
+    #[error("algorithm parameter error: {0}")]
+    AlgorithmParameter(#[from] pkix_types::algorithm::parameters::Error),
+
     #[error("JSON serialization error: {0}")]
     Json(#[from] serde_json::Error),
 
@@ -44,35 +47,51 @@ pub(crate) enum Error {
     #[error("Formatting error: {0}")]
     Fmt(#[from] std::fmt::Error),
 
-    #[error("cannot extract public key from {0}")]
-    PublicKeyExtraction(String),
+    // Input validation errors
+    #[error("invalid hostname: {0}")]
+    InvalidHostname(String),
+    #[error("--remote cannot be used with file input")]
+    RemoteWithFileInput,
+    #[error("unsupported PEM label: {0}")]
+    UnsupportedPemLabel(String),
 
-    #[error("Invalid input: {0}")]
-    InvalidInput(String),
+    // Connection errors
+    #[error("failed to connect to {host}:{port}: {reason}")]
+    ConnectionFailed {
+        host: String,
+        port: u16,
+        reason: String,
+    },
 
-    #[error("TLS error: {0}")]
-    Tls(String),
+    // TLS errors
+    #[error("failed to create TLS connection: {0}")]
+    TlsConnectionFailed(String),
+    #[error("TLS handshake failed: {0}")]
+    TlsHandshakeFailed(String),
+    #[error("no certificates received from server")]
+    NoCertificatesReceived,
 
-    #[error("Certificate error: {0}")]
-    Certificate(String),
+    // Certificate errors
+    #[error("no certificates found")]
+    NoCertificatesFound,
+    #[error("certificate index {index} out of range (chain has {total} certificates)")]
+    CertificateIndexOutOfRange { index: usize, total: usize },
+    #[error("failed to parse certificate chain: {0}")]
+    CertificateChainParseFailed(String),
 
-    #[error("Connection error: {0}")]
-    Connection(String),
+    // Key extraction errors
+    #[error("cannot extract public key: unsupported key format (only RSA-PKCS#1, PKCS#8, or SEC1)")]
+    UnsupportedKeyFormat,
+    #[error("cannot extract public key from {0} key")]
+    PublicKeyExtractionFailed(String),
 
-    #[error("{0}")]
-    Message(String),
-}
-
-impl From<&str> for Error {
-    fn from(s: &str) -> Self {
-        Error::Message(s.to_string())
-    }
-}
-
-impl From<String> for Error {
-    fn from(s: String) -> Self {
-        Error::Message(s)
-    }
+    // Decode errors
+    #[error("failed to decode private key: {0}")]
+    PrivateKeyDecodeFailed(String),
+    #[error("failed to decode public key: {0}")]
+    PublicKeyDecodeFailed(String),
+    #[error("cannot determine key size for: {0}")]
+    CannotDetermineKeySize(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -48,7 +48,14 @@ enum Commands {
     },
 }
 
-fn main() -> Result<()> {
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {

--- a/cli/src/pkcs/inspect/sec1.rs
+++ b/cli/src/pkcs/inspect/sec1.rs
@@ -35,7 +35,8 @@ pub(crate) fn output_ec_private_key(
             if let Some(curve) = private_key.parameters {
                 let curve_name = curve.oid_name().unwrap_or("unknown");
                 if config.show_oid {
-                    writeln!(output, "Curve: {} ({})", curve_name, curve.oid())?;
+                    let oid = curve.oid()?;
+                    writeln!(output, "Curve: {} ({})", curve_name, oid)?;
                 } else {
                     writeln!(output, "Curve: {}", curve_name)?;
                 }
@@ -61,7 +62,8 @@ pub(crate) fn output_ec_private_key(
                 // Show curve OID if not already showing it
                 if !config.show_oid {
                     if let Some(curve) = private_key.parameters {
-                        writeln!(output, "Curve OID: {}", curve.oid())?;
+                        let oid = curve.oid()?;
+                        writeln!(output, "Curve OID: {}", oid)?;
                     }
                 }
 

--- a/der/src/lib.rs
+++ b/der/src/lib.rs
@@ -141,11 +141,9 @@ impl Encoder<Tag, u8> for Tag {
         Ok(match self {
             Tag::Primitive(_, value) => *value,
             Tag::ContextSpecific { slot, constructed } => {
-                let mut tag = 0x80; // Context-specific class
-                if *constructed {
-                    tag |= TAG_CONSTRUCTED;
-                }
-                tag | slot
+                let base = 0x80; // Context-specific class
+                let constructed_bit = if *constructed { TAG_CONSTRUCTED } else { 0 };
+                base | constructed_bit | slot
             }
         })
     }
@@ -574,8 +572,8 @@ mod tests {
                             actual_tlvs.len()
                         )
                     }
-                    for i in 0..expected_tlvs.len() {
-                        compare_primitive_tlv(&expected_tlvs[i], &actual_tlvs[i]);
+                    for (expected, actual) in expected_tlvs.iter().zip(actual_tlvs.iter()) {
+                        compare_primitive_tlv(expected, actual);
                     }
                 }
             },

--- a/pem/src/lib.rs
+++ b/pem/src/lib.rs
@@ -121,7 +121,8 @@ impl Display for Pem {
         writeln!(f, "-----BEGIN {}-----", self.label)?;
         // RFC 7468: base64 text should be wrapped at 64 characters
         for chunk in self.base64_data.as_bytes().chunks(64) {
-            writeln!(f, "{}", std::str::from_utf8(chunk).unwrap())?;
+            let line = std::str::from_utf8(chunk).map_err(|_| std::fmt::Error)?;
+            writeln!(f, "{}", line)?;
         }
         write!(f, "-----END {}-----", self.label)
     }

--- a/pkcs/src/pkcs1/error.rs
+++ b/pkcs/src/pkcs1/error.rs
@@ -5,17 +5,32 @@ pub enum Error {
     #[error("ASN.1 error: {0}")]
     Asn1(#[from] asn1::error::Error),
 
-    #[error("Invalid PKCS#1 structure: {0}")]
-    InvalidStructure(String),
+    #[error("expected SEQUENCE")]
+    ExpectedSequence,
+
+    #[error("expected {expected} elements, got {actual}")]
+    InvalidElementCount {
+        expected: &'static str,
+        actual: usize,
+    },
+
+    #[error("expected INTEGER for {field}")]
+    ExpectedInteger { field: &'static str },
+
+    #[error("empty ASN1Object")]
+    EmptyAsn1Object,
+
+    #[error("unexpected key format: expected {expected}")]
+    UnexpectedKeyFormat { expected: &'static str },
 
     #[error("Invalid version: {0} (must be 0 for two-prime or 1 for multi-prime)")]
     InvalidVersion(i64),
 
     #[error("Missing required field: {0}")]
-    MissingField(String),
+    MissingField(&'static str),
 
-    #[error("Invalid integer value: {0}")]
-    InvalidInteger(String),
+    #[error("version out of range for i64")]
+    VersionOutOfRange,
 
     #[error("Invalid PEM: {0}")]
     InvalidPem(#[from] pem::error::Error),

--- a/pkcs/src/pkcs8/error.rs
+++ b/pkcs/src/pkcs8/error.rs
@@ -7,8 +7,29 @@ pub enum Error {
     #[error("Invalid version: {0}")]
     InvalidVersion(i64),
 
-    #[error("Invalid structure: {0}")]
-    InvalidStructure(String),
+    #[error("expected SEQUENCE")]
+    ExpectedSequence,
+
+    #[error("expected {expected} elements, got {actual}")]
+    InvalidElementCount {
+        expected: &'static str,
+        actual: usize,
+    },
+
+    #[error("expected OCTET STRING for {field}")]
+    ExpectedOctetString { field: &'static str },
+
+    #[error("expected INTEGER for version")]
+    ExpectedVersionInteger,
+
+    #[error("empty ASN1Object")]
+    EmptyAsn1Object,
+
+    #[error("failed to encode SubjectPublicKeyInfo")]
+    SubjectPublicKeyInfoEncodingFailed,
+
+    #[error("unexpected key format: expected {expected}")]
+    UnexpectedKeyFormat { expected: &'static str },
 
     #[error("ASN.1 error: {0}")]
     Asn1(#[from] asn1::error::Error),
@@ -22,15 +43,6 @@ pub enum Error {
     #[error("Invalid algorithm identifier")]
     InvalidAlgorithmIdentifier,
 
-    #[error("Missing required field: {0}")]
-    MissingField(String),
-
-    #[error("Decryption error: {0}")]
-    DecryptionError(String),
-
     #[error("PKCS#9 attribute error: {0}")]
     Pkcs9(#[from] crate::pkcs9::error::Error),
-
-    #[error("Invalid public key: {0}")]
-    InvalidPublicKey(String),
 }

--- a/pkcs/src/pkcs9/error.rs
+++ b/pkcs/src/pkcs9/error.rs
@@ -8,60 +8,146 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// PKCS#9 error types
 #[derive(Debug, Error)]
 pub enum Error {
-    /// Invalid PKCS#9 attribute structure
-    #[error("Invalid PKCS#9 attribute: {0}")]
-    InvalidAttribute(String),
+    // Attribute general errors
+    /// Attribute: expected SEQUENCE
+    #[error("Attribute: expected SEQUENCE")]
+    AttributeExpectedSequence,
 
-    /// Invalid contentType attribute
-    #[error("Invalid contentType: {0}")]
-    InvalidContentType(String),
+    /// Attribute: expected 2 elements (attributeType, attributeValues)
+    #[error("Attribute: expected 2 elements, got {0}")]
+    AttributeInvalidElementCount(usize),
 
-    /// Invalid messageDigest attribute
-    #[error("Invalid messageDigest: {0}")]
-    InvalidMessageDigest(String),
+    /// Attribute: expected OBJECT IDENTIFIER for attributeType
+    #[error("Attribute: expected OBJECT IDENTIFIER for attributeType")]
+    AttributeExpectedOid,
 
-    /// Invalid signingTime attribute
-    #[error("Invalid signingTime: {0}")]
-    InvalidSigningTime(String),
+    /// Attribute: expected SET for attributeValues
+    #[error("Attribute: expected SET for attributeValues")]
+    AttributeExpectedSet,
 
-    /// Invalid challengePassword attribute
-    #[error("Invalid challengePassword: {0}")]
-    InvalidChallengePassword(String),
+    /// Attribute: empty ASN1Object
+    #[error("{0}: empty ASN1Object")]
+    AttributeEmptyAsn1Object(&'static str),
 
-    /// Invalid unstructuredName attribute
-    #[error("Invalid unstructuredName: {0}")]
-    InvalidUnstructuredName(String),
+    /// Attribute: values SET is empty
+    #[error("{0}: values SET is empty")]
+    AttributeEmptyValuesSet(&'static str),
 
-    /// Invalid unstructuredAddress attribute
-    #[error("Invalid unstructuredAddress: {0}")]
-    InvalidUnstructuredAddress(String),
+    /// Attribute: expected exactly one value, got {actual}
+    #[error("{attr}: expected exactly one value, got {actual}")]
+    AttributeInvalidValueCount { attr: &'static str, actual: usize },
 
-    /// Invalid smimeCapabilities attribute
-    #[error("Invalid smimeCapabilities: {0}")]
-    InvalidSmimeCapabilities(String),
+    /// Attribute: expected element type
+    #[error("{attr}: expected {expected}")]
+    AttributeExpectedElementType {
+        attr: &'static str,
+        expected: &'static str,
+    },
 
-    /// Invalid countersignature attribute
-    #[error("Invalid countersignature: {0}")]
-    InvalidCountersignature(String),
+    /// Attributes: expected SET
+    #[error("Attributes: must be a SET")]
+    AttributesExpectedSet,
 
-    /// Invalid extensionRequest attribute
-    #[error("Invalid extensionRequest: {0}")]
-    InvalidExtensionRequest(String),
+    /// Invalid contentType attribute - expected OBJECT IDENTIFIER
+    #[error("invalid contentType: expected OBJECT IDENTIFIER")]
+    InvalidContentTypeExpectedOid,
 
-    /// Invalid friendlyName attribute
-    #[error("Invalid friendlyName: {0}")]
-    InvalidFriendlyName(String),
+    /// Invalid messageDigest attribute - expected OCTET STRING
+    #[error("invalid messageDigest: expected OCTET STRING")]
+    InvalidMessageDigestExpectedOctetString,
 
-    /// Invalid localKeyId attribute
-    #[error("Invalid localKeyId: {0}")]
-    InvalidLocalKeyId(String),
+    // signingTime errors
+    /// signingTime: invalid RFC3339 format
+    #[error("signingTime: invalid RFC3339 format: {0}")]
+    SigningTimeInvalidRfc3339(String),
+
+    /// signingTime: invalid date/time from UTCTime
+    #[error("signingTime: invalid date/time from UTCTime")]
+    SigningTimeInvalidDateTime,
+
+    /// signingTime: expected UTCTime or GeneralizedTime
+    #[error("signingTime: expected UTCTime or GeneralizedTime")]
+    SigningTimeExpectedTime,
+
+    // challengePassword errors
+    /// challengePassword: invalid encoding
+    #[error("challengePassword: invalid encoding: {0}")]
+    ChallengePasswordInvalidEncoding(String),
+
+    // unstructuredName errors
+    /// unstructuredName: expected IA5String or DirectoryString
+    #[error("unstructuredName: expected IA5String or DirectoryString, got {0}")]
+    UnstructuredNameInvalidType(String),
+
+    // unstructuredAddress errors
+    /// unstructuredAddress: expected DirectoryString
+    #[error("unstructuredAddress: expected DirectoryString, got {0}")]
+    UnstructuredAddressInvalidType(String),
+
+    // smimeCapabilities errors
+    /// smimeCapabilities: expected SEQUENCE for SMIMECapability
+    #[error("smimeCapabilities: expected SEQUENCE for SMIMECapability")]
+    SmimeCapabilitiesExpectedSequence,
+
+    /// smimeCapabilities: expected OBJECT IDENTIFIER for capabilityID
+    #[error("smimeCapabilities: expected OBJECT IDENTIFIER for capabilityID")]
+    SmimeCapabilitiesExpectedOid,
+
+    /// smimeCapabilities: expected 1 or 2 elements in SMIMECapability
+    #[error("smimeCapabilities: expected 1 or 2 elements, got {0}")]
+    SmimeCapabilitiesInvalidElementCount(usize),
+
+    // countersignature errors
+    /// countersignature: expected SEQUENCE for SignerInfo
+    #[error("countersignature: expected SEQUENCE for SignerInfo, got {0}")]
+    CountersignatureExpectedSequence(String),
+
+    /// countersignature: invalid version value
+    #[error("countersignature: invalid version value")]
+    CountersignatureInvalidVersion,
+
+    /// countersignature: missing required field
+    #[error("countersignature: missing {0}")]
+    CountersignatureMissingField(&'static str),
+
+    /// countersignature: expected element type
+    #[error("countersignature: expected {expected}, got {actual}")]
+    CountersignatureExpectedType {
+        expected: &'static str,
+        actual: String,
+    },
+
+    /// countersignature: invalid element count
+    #[error("countersignature: expected {expected} elements, got {actual}")]
+    CountersignatureInvalidElementCount { expected: usize, actual: usize },
+
+    // extensionRequest errors
+    /// extensionRequest: expected SEQUENCE for Extensions
+    #[error("extensionRequest: expected SEQUENCE for Extensions")]
+    ExtensionRequestExpectedSequence,
+
+    /// extensionRequest: expected exactly one value
+    #[error("extensionRequest: expected exactly one value, got {0}")]
+    ExtensionRequestInvalidValueCount(usize),
+
+    /// Invalid friendlyName attribute - expected BMPString
+    #[error("invalid friendlyName: expected BMPString")]
+    InvalidFriendlyNameExpectedBmpString,
+
+    /// Invalid friendlyName attribute - BMPString conversion failed
+    #[error("invalid friendlyName: BMPString conversion failed: {0}")]
+    InvalidFriendlyNameBmpStringConversion(String),
+
+    /// Invalid localKeyId attribute - expected OCTET STRING
+    #[error("invalid localKeyId: expected OCTET STRING")]
+    InvalidLocalKeyIdExpectedOctetString,
 
     /// Empty attribute name or value
     #[error("{0} cannot be empty")]
     EmptyValue(String),
 
     /// Value exceeds maximum length
-    #[error("Value too long: {actual} characters (max: {max})")]
+    #[error("value too long: {actual} characters (max: {max})")]
     ValueTooLong { max: usize, actual: usize },
 
     /// OID mismatch between expected and actual
@@ -81,6 +167,6 @@ pub enum Error {
     PkixTypesError(#[from] pkix_types::Error),
 
     /// Unsupported attribute type
-    #[error("Unsupported attribute type: {0}")]
+    #[error("unsupported attribute type: {0}")]
     UnsupportedAttribute(String),
 }

--- a/pkcs/src/sec1/error.rs
+++ b/pkcs/src/sec1/error.rs
@@ -1,5 +1,6 @@
 //! SEC1 (RFC 5915) error types
 
+use asn1::ObjectIdentifier;
 use thiserror::Error;
 
 /// Errors that can occur when parsing or encoding SEC1 structures.
@@ -21,6 +22,10 @@ pub enum Error {
     #[error("PKIX types error: {0}")]
     PkixTypes(#[from] pkix_types::Error),
 
+    /// Algorithm parameter error
+    #[error("algorithm parameter error: {0}")]
+    AlgorithmParameter(#[from] pkix_types::algorithm::parameters::Error),
+
     /// Expected a SEQUENCE element but got something else
     #[error("expected SEQUENCE")]
     ExpectedSequence,
@@ -33,9 +38,9 @@ pub enum Error {
     #[error("expected OCTET STRING")]
     ExpectedOctetString,
 
-    /// The sequence has fewer elements than required
-    #[error("insufficient elements: {0}")]
-    InsufficientElements(String),
+    /// Missing required fields in the structure
+    #[error("missing required fields: version or privateKey")]
+    MissingRequiredFields,
 
     /// The ASN.1 object contains no elements
     #[error("empty ASN.1 object")]
@@ -51,7 +56,11 @@ pub enum Error {
 
     /// Unknown or unsupported elliptic curve OID
     #[error("unknown curve OID: {0}")]
-    UnknownCurve(String),
+    UnknownCurveOid(ObjectIdentifier),
+
+    /// Invalid parameters element (expected OBJECT IDENTIFIER)
+    #[error("invalid parameters: expected OBJECT IDENTIFIER")]
+    InvalidParametersExpectedOid,
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/pkix-types/src/algorithm/error.rs
+++ b/pkix-types/src/algorithm/error.rs
@@ -5,9 +5,25 @@ use thiserror::Error;
 /// Algorithm Error
 #[derive(Debug, Error)]
 pub enum Error {
-    /// Invalid algorithm identifier
-    #[error("Invalid algorithm identifier: {0}")]
-    InvalidAlgorithmIdentifier(String),
+    /// NULL parameter cannot be converted to a typed parameter
+    #[error("cannot convert NULL to typed parameter")]
+    NullParameterNotSupported,
+
+    /// AlgorithmIdentifier algorithm field must be an OID
+    #[error("AlgorithmIdentifier algorithm must be OBJECT IDENTIFIER")]
+    ExpectedOidForAlgorithm,
+
+    /// AlgorithmIdentifier is empty (must have at least algorithm OID)
+    #[error("AlgorithmIdentifier must have at least 1 element")]
+    EmptyAlgorithmIdentifier,
+
+    /// AlgorithmIdentifier has too many elements
+    #[error("AlgorithmIdentifier must have at most 2 elements")]
+    TooManyElements,
+
+    /// AlgorithmIdentifier must be a SEQUENCE
+    #[error("AlgorithmIdentifier must be a SEQUENCE")]
+    ExpectedSequence,
 
     /// Algorithm parameter error
     #[error(transparent)]

--- a/pkix-types/src/algorithm/parameters/error.rs
+++ b/pkix-types/src/algorithm/parameters/error.rs
@@ -28,6 +28,10 @@ pub enum Error {
     /// Cannot convert NULL to typed parameter
     #[error("Cannot convert NULL to typed parameter")]
     NullConversion,
+
+    /// Invalid OID string
+    #[error("Invalid OID: {0}")]
+    InvalidOid(String),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;

--- a/pkix-types/src/directory_string.rs
+++ b/pkix-types/src/directory_string.rs
@@ -148,16 +148,12 @@ impl TryFrom<&Element> for DirectoryString {
             Element::OctetString(os) => {
                 // May come as OctetString due to IMPLICIT tagging
                 // Default to UTF8String encoding for OctetString
-                let s = String::from_utf8(os.as_bytes().to_vec()).map_err(|e| {
-                    Error::InvalidDirectoryString(format!("invalid UTF-8 in OctetString: {}", e))
-                })?;
+                let s = String::from_utf8(os.as_bytes().to_vec())
+                    .map_err(|_| Error::DirectoryStringInvalidUtf8)?;
                 (s, StringEncoding::UTF8String)
             }
-            other => {
-                return Err(Error::InvalidDirectoryString(format!(
-                    "DirectoryString must be a string type, got {:?}",
-                    other
-                )))
+            _ => {
+                return Err(Error::DirectoryStringExpectedStringType);
             }
         };
         Ok(Self { value, encoding })

--- a/pkix-types/src/error.rs
+++ b/pkix-types/src/error.rs
@@ -8,45 +8,51 @@ pub type Result<T> = std::result::Result<T, Error>;
 /// PKIX types error types
 #[derive(Debug, Error)]
 pub enum Error {
-    /// Invalid DirectoryString
-    #[error("Invalid DirectoryString: {0}")]
-    InvalidDirectoryString(String),
+    // DirectoryString errors
+    #[error("DirectoryString: invalid UTF-8 in OctetString")]
+    DirectoryStringInvalidUtf8,
+    #[error("DirectoryString: expected string type")]
+    DirectoryStringExpectedStringType,
 
-    /// Invalid AlgorithmIdentifier
-    #[error("Invalid AlgorithmIdentifier: {0}")]
-    InvalidAlgorithmIdentifier(String),
+    // Extension errors
+    #[error("Extension: expected SEQUENCE")]
+    ExtensionExpectedSequence,
+    #[error("Extension: expected 2 or 3 elements, got {0}")]
+    ExtensionInvalidElementCount(usize),
+    #[error("Extension: expected OCTET STRING for extnValue")]
+    ExtensionExpectedOctetString,
+    #[error("Extension: expected BOOLEAN for critical or OCTET STRING for extnValue")]
+    ExtensionInvalidCriticalOrValue,
+    #[error("Extension: expected OBJECT IDENTIFIER for extnID")]
+    ExtensionExpectedOidForExtnId,
 
-    /// Invalid Extension
-    #[error("Invalid Extension: {0}")]
-    InvalidExtension(String),
+    // Name errors
+    #[error("Name: expected SEQUENCE")]
+    NameExpectedSequence,
 
-    /// Invalid Name
-    #[error("Invalid Name: {0}")]
-    InvalidName(String),
+    // RelativeDistinguishedName errors
+    #[error("RelativeDistinguishedName: expected SET")]
+    RdnExpectedSet,
 
-    /// Invalid RelativeDistinguishedName
-    #[error("Invalid RelativeDistinguishedName: {0}")]
-    InvalidRelativeDistinguishedName(String),
+    // AttributeTypeAndValue errors
+    #[error("AttributeTypeAndValue: expected SEQUENCE")]
+    AttributeTypeAndValueExpectedSequence,
+    #[error("AttributeTypeAndValue: expected OBJECT IDENTIFIER for attribute type")]
+    AttributeTypeAndValueExpectedOid,
+    #[error("AttributeTypeAndValue: expected 2 elements")]
+    AttributeTypeAndValueInvalidElementCount,
 
-    /// Invalid AttributeTypeAndValue
-    #[error("Invalid AttributeTypeAndValue: {0}")]
-    InvalidAttributeTypeAndValue(String),
+    // CertificateSerialNumber errors
+    #[error("CertificateSerialNumber: expected INTEGER")]
+    CertificateSerialNumberExpectedInteger,
 
-    /// Invalid CertificateSerialNumber
-    #[error("Invalid CertificateSerialNumber: {0}")]
-    InvalidCertificateSerialNumber(String),
-
-    /// Invalid KeyIdentifier
-    #[error("Invalid KeyIdentifier: {0}")]
-    InvalidKeyIdentifier(String),
-
-    /// Invalid SubjectPublicKeyInfo
-    #[error("Invalid SubjectPublicKeyInfo: {0}")]
-    InvalidSubjectPublicKeyInfo(String),
-
-    /// Invalid encoding
-    #[error("Invalid encoding: {0}")]
-    InvalidEncoding(String),
+    // SubjectPublicKeyInfo errors
+    #[error("SubjectPublicKeyInfo: expected SEQUENCE")]
+    SubjectPublicKeyInfoExpectedSequence,
+    #[error("SubjectPublicKeyInfo: expected BIT STRING for subject public key")]
+    SubjectPublicKeyInfoExpectedBitString,
+    #[error("SubjectPublicKeyInfo: expected 2 elements, got {0}")]
+    SubjectPublicKeyInfoInvalidElementCount(usize),
 
     /// Algorithm error
     #[error(transparent)]

--- a/pkix-types/src/serial_number.rs
+++ b/pkix-types/src/serial_number.rs
@@ -95,9 +95,7 @@ impl Decoder<Element, CertificateSerialNumber> for Element {
     fn decode(&self) -> Result<CertificateSerialNumber> {
         match self {
             Element::Integer(i) => Ok(CertificateSerialNumber { inner: i.clone() }),
-            _ => Err(Error::InvalidCertificateSerialNumber(
-                "expected Integer for CertificateSerialNumber".to_string(),
-            )),
+            _ => Err(Error::CertificateSerialNumberExpectedInteger),
         }
     }
 }

--- a/x509/src/extensions/error.rs
+++ b/x509/src/extensions/error.rs
@@ -1,0 +1,235 @@
+//! Extension-specific error types
+
+use thiserror::Error;
+
+/// Context for where an extension error occurred
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Kind {
+    BasicConstraints,
+    KeyUsage,
+    SubjectKeyIdentifier,
+    AuthorityKeyIdentifier,
+    SubjectAltName,
+    IssuerAltName,
+    GeneralName,
+    ExtendedKeyUsage,
+    AuthorityInfoAccess,
+    NameConstraints,
+    CRLDistributionPoints,
+    CertificatePolicies,
+    InhibitAnyPolicy,
+    PolicyConstraints,
+    PolicyMappings,
+}
+
+impl std::fmt::Display for Kind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::BasicConstraints => write!(f, "BasicConstraints"),
+            Self::KeyUsage => write!(f, "KeyUsage"),
+            Self::SubjectKeyIdentifier => write!(f, "SubjectKeyIdentifier"),
+            Self::AuthorityKeyIdentifier => write!(f, "AuthorityKeyIdentifier"),
+            Self::SubjectAltName => write!(f, "SubjectAltName"),
+            Self::IssuerAltName => write!(f, "IssuerAltName"),
+            Self::GeneralName => write!(f, "GeneralName"),
+            Self::ExtendedKeyUsage => write!(f, "ExtendedKeyUsage"),
+            Self::AuthorityInfoAccess => write!(f, "AuthorityInfoAccess"),
+            Self::NameConstraints => write!(f, "NameConstraints"),
+            Self::CRLDistributionPoints => write!(f, "CRLDistributionPoints"),
+            Self::CertificatePolicies => write!(f, "CertificatePolicies"),
+            Self::InhibitAnyPolicy => write!(f, "InhibitAnyPolicy"),
+            Self::PolicyConstraints => write!(f, "PolicyConstraints"),
+            Self::PolicyMappings => write!(f, "PolicyMappings"),
+        }
+    }
+}
+
+/// Extension parsing errors
+#[derive(Debug, Error)]
+pub enum Error {
+    // Common structural errors
+    #[error("{0}: empty sequence")]
+    EmptySequence(Kind),
+
+    #[error("{0}: expected SEQUENCE")]
+    ExpectedSequence(Kind),
+
+    #[error("{0}: expected BIT STRING")]
+    ExpectedBitString(Kind),
+
+    #[error("{0}: expected OCTET STRING")]
+    ExpectedOctetString(Kind),
+
+    #[error("{0}: expected INTEGER")]
+    ExpectedInteger(Kind),
+
+    #[error("{0}: expected OBJECT IDENTIFIER")]
+    ExpectedOid(Kind),
+
+    #[error("{kind}: expected context-specific tag [{expected}]")]
+    ExpectedContextTag { kind: Kind, expected: u8 },
+
+    #[error("{kind}: expected {expected} elements, got {actual}")]
+    InvalidElementCount {
+        kind: Kind,
+        expected: &'static str,
+        actual: usize,
+    },
+
+    #[error("{0}: unexpected element type")]
+    UnexpectedElementType(Kind),
+
+    // BasicConstraints specific errors
+    #[error("BasicConstraints: pathLenConstraint out of range for u32")]
+    PathLenConstraintOutOfRange,
+
+    // GeneralName specific errors
+    #[error("GeneralName: unknown context-specific tag [{0}]")]
+    UnknownGeneralNameTag(u8),
+
+    #[error("GeneralName: IA5String must be valid ASCII")]
+    GeneralNameInvalidAscii,
+
+    #[error("GeneralName: iPAddress must be 4, 8, 16, or 32 bytes, got {0}")]
+    InvalidIpAddressLength(usize),
+
+    #[error("GeneralName: invalid IPv4 network: {0}")]
+    InvalidIpv4Network(String),
+
+    #[error("GeneralName: invalid IPv6 network: {0}")]
+    InvalidIpv6Network(String),
+
+    #[error("GeneralName: invalid OID encoding")]
+    InvalidOidEncoding,
+
+    #[error("GeneralName: otherName requires at least 2 elements")]
+    OtherNameInvalidElementCount,
+
+    #[error("GeneralName: otherName type-id must be OBJECT IDENTIFIER")]
+    OtherNameExpectedOid,
+
+    #[error("GeneralName: otherName value must be [0] EXPLICIT")]
+    OtherNameExpectedExplicitTag,
+
+    #[error("GeneralName: ediPartyName missing required partyName [1]")]
+    EdiPartyNameMissingPartyName,
+
+    #[error("GeneralName: invalid nameAssigner in ediPartyName")]
+    EdiPartyNameInvalidNameAssigner,
+
+    #[error("GeneralName: invalid partyName in ediPartyName")]
+    EdiPartyNameInvalidPartyName,
+
+    // SubjectAltName / IssuerAltName specific errors
+    #[error("{0}: at least one GeneralName required")]
+    AtLeastOneGeneralNameRequired(Kind),
+
+    // AuthorityKeyIdentifier specific errors
+    #[error("AuthorityKeyIdentifier: keyIdentifier must be OCTET STRING")]
+    AkiKeyIdentifierNotOctetString,
+
+    #[error("AuthorityKeyIdentifier: authorityCertIssuer must be SEQUENCE (GeneralNames)")]
+    AkiAuthorityCertIssuerNotSequence,
+
+    #[error("AuthorityKeyIdentifier: serialNumber must be OCTET STRING or INTEGER")]
+    AkiSerialNumberInvalidType,
+
+    // ExtendedKeyUsage specific errors
+    #[error("ExtendedKeyUsage: at least one KeyPurposeId required")]
+    ExtendedKeyUsageEmpty,
+
+    #[error("ExtendedKeyUsage: all elements must be OBJECT IDENTIFIER")]
+    ExtendedKeyUsageExpectedOid,
+
+    // InhibitAnyPolicy / PolicyConstraints specific errors
+    #[error("{0}: empty content")]
+    EmptyContent(Kind),
+
+    #[error("{0}: value out of range for u32")]
+    ValueOutOfRangeU32(Kind),
+
+    // NameConstraints specific errors
+    #[error(
+        "NameConstraints: at least one of permittedSubtrees or excludedSubtrees must be present"
+    )]
+    NameConstraintsEmptyContent,
+
+    #[error("NameConstraints: invalid element in sequence")]
+    NameConstraintsInvalidElement,
+
+    // CRLDistributionPoints specific errors
+    #[error("CRLDistributionPoints: at least one DistributionPoint required")]
+    CrlDistributionPointsEmpty,
+
+    #[error("CRLDistributionPoints: unknown context tag [{0}]")]
+    CrlDistributionPointsUnknownTag(u8),
+
+    // CertificatePolicies specific errors
+    #[error("CertificatePolicies: at least one PolicyInformation required")]
+    CertificatePoliciesEmpty,
+
+    #[error("CertificatePolicies: PolicyInformation must be SEQUENCE")]
+    PolicyInformationExpectedSequence,
+
+    #[error(
+        "CertificatePolicies: PolicyInformation requires at least 1 element (policyIdentifier)"
+    )]
+    PolicyInformationMissingIdentifier,
+
+    #[error("CertificatePolicies: policyIdentifier must be OBJECT IDENTIFIER")]
+    PolicyInformationExpectedOid,
+
+    #[error("CertificatePolicies: policyQualifiers must be SEQUENCE")]
+    PolicyQualifiersExpectedSequence,
+
+    #[error("CertificatePolicies: PolicyQualifierInfo must be SEQUENCE")]
+    PolicyQualifierInfoExpectedSequence,
+
+    #[error("CertificatePolicies: PolicyQualifierInfo requires 2 elements")]
+    PolicyQualifierInfoInvalidElementCount,
+
+    #[error("CertificatePolicies: policyQualifierId must be OBJECT IDENTIFIER")]
+    PolicyQualifierIdExpectedOid,
+
+    #[error("CertificatePolicies: UserNotice must be SEQUENCE")]
+    UserNoticeExpectedSequence,
+
+    #[error("CertificatePolicies: NoticeReference must be SEQUENCE with 2 elements")]
+    NoticeReferenceInvalidStructure,
+
+    #[error("CertificatePolicies: noticeNumbers must be SEQUENCE")]
+    NoticeNumbersExpectedSequence,
+
+    #[error("CertificatePolicies: noticeNumbers must contain INTEGER values")]
+    NoticeNumbersExpectedIntegers,
+
+    // PolicyMappings specific errors
+    #[error("PolicyMappings: at least one mapping required")]
+    PolicyMappingsEmpty,
+
+    #[error("PolicyMappings: PolicyMapping must be SEQUENCE with 2 elements")]
+    PolicyMappingInvalidStructure,
+
+    #[error("PolicyMappings: issuerDomainPolicy must be OBJECT IDENTIFIER")]
+    PolicyMappingIssuerExpectedOid,
+
+    #[error("PolicyMappings: subjectDomainPolicy must be OBJECT IDENTIFIER")]
+    PolicyMappingSubjectExpectedOid,
+
+    // AuthorityInfoAccess specific errors
+    #[error("AuthorityInfoAccess: at least one AccessDescription required")]
+    AuthorityInfoAccessEmpty,
+
+    #[error("AuthorityInfoAccess: AccessDescription must be SEQUENCE with 2 elements")]
+    AccessDescriptionInvalidStructure,
+
+    #[error("AuthorityInfoAccess: accessMethod must be OBJECT IDENTIFIER")]
+    AccessDescriptionExpectedOid,
+
+    /// Invalid ASN.1 structure
+    #[error("invalid ASN.1: {0}")]
+    InvalidAsn1(#[source] asn1::error::Error),
+}
+
+/// Result type for extension operations
+pub type Result<T> = std::result::Result<T, Error>;

--- a/x509/src/types.rs
+++ b/x509/src/types.rs
@@ -99,19 +99,19 @@ mod tests {
         // Test case: Not a sequence
         case(
             Element::Integer(Integer::from(vec![0x01])),
-            "InvalidAttributeTypeAndValue"
+            "AttributeTypeAndValueExpectedSequence"
         ),
         // Test case: Empty sequence
         case(
             Element::Sequence(vec![]),
-            "InvalidAttributeTypeAndValue"
+            "AttributeTypeAndValueInvalidElementCount"
         ),
         // Test case: Only one element
         case(
             Element::Sequence(vec![
                 Element::ObjectIdentifier(ObjectIdentifier::from_str("2.5.4.3").unwrap())
             ]),
-            "InvalidAttributeTypeAndValue"
+            "AttributeTypeAndValueInvalidElementCount"
         ),
         // Test case: Invalid attribute type (not an OID)
         case(
@@ -119,7 +119,7 @@ mod tests {
                 Element::Integer(Integer::from(vec![0x01])),
                 Element::UTF8String("value".to_string())
             ]),
-            "InvalidAttributeTypeAndValue"
+            "AttributeTypeAndValueExpectedOid"
         )
     )]
     fn test_attribute_type_and_value_decode_failure(input: Element, expected_error_type: &str) {
@@ -207,12 +207,12 @@ mod tests {
         // Test case: Not a Set (should return RDN error)
         case(
             Element::Sequence(vec![]),
-            "InvalidRelativeDistinguishedName"
+            "RdnExpectedSet"
         ),
         // Test case: Invalid attribute (should propagate AttributeTypeAndValue error)
         case(
             Element::Set(vec![Element::Integer(Integer::from(vec![0x01]))]),
-            "InvalidAttributeTypeAndValue"
+            "AttributeTypeAndValueExpectedSequence"
         ),
         // Test case: Set with partially invalid attributes
         case(
@@ -223,7 +223,7 @@ mod tests {
                 ]),
                 Element::Integer(Integer::from(vec![0x01])) // Invalid
             ]),
-            "InvalidAttributeTypeAndValue"
+            "AttributeTypeAndValueExpectedSequence"
         )
     )]
     fn test_rdn_decode_failure(input: Element, expected_error_variant: &str) {
@@ -332,19 +332,19 @@ mod tests {
         // Test case: Not a Sequence (should return Name error)
         case(
             Element::Integer(Integer::from(vec![0x01])),
-            "InvalidName"
+            "NameExpectedSequence"
         ),
         // Test case: Invalid RDN (should propagate RDN error)
         case(
             Element::Sequence(vec![Element::Integer(Integer::from(vec![0x01]))]),
-            "InvalidRelativeDistinguishedName"
+            "RdnExpectedSet"
         ),
         // Test case: Invalid AttributeTypeAndValue (should propagate through the chain)
         case(
             Element::Sequence(vec![
                 Element::Set(vec![Element::Integer(Integer::from(vec![0x01]))])
             ]),
-            "InvalidAttributeTypeAndValue"
+            "AttributeTypeAndValueExpectedSequence"
         ),
         // Test case: Multiple RDNs with one invalid (should fail on first error)
         case(
@@ -357,7 +357,7 @@ mod tests {
                 ]),
                 Element::Integer(Integer::from(vec![0x01])) // Invalid RDN
             ]),
-            "InvalidRelativeDistinguishedName"
+            "RdnExpectedSet"
         )
     )]
     fn test_name_decode_failure(input: Element, expected_error_variant: &str) {


### PR DESCRIPTION
- Replace all String-based error variants with structured error types
  across asn1, pkix-types, pkcs, x509, and cli crates
- Add context-specific error variants for better type safety
- Remove 9 unused error variants from x509/src/error.rs
- Refactor cli/cert/inspect/mod.rs to functional programming style
  - Use bool.then() and flatten() instead of imperative if statements
  - Use iterator .any() for should_show_specific_fields()
- Fix error display in CLI to use Display format instead of Debug
- Update all test assertions to match new error messages

All tests passing (1,042+), clippy clean, formatted.

Signed-off-by: terashima <iscale821@gmail.com>
Signed-off-by: Claude Code <claude-code@anthropic.com>
