### PR TITLE
ci: add deps to allowed PR title scopes

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -33,6 +33,7 @@ jobs:
             pkcs
             x509
             cli
+            deps
           requireScope: false
           subjectPattern: ^.+$
           subjectPatternError: |


### PR DESCRIPTION
Allow Dependabot PRs with chore(deps) scope to pass the semantic PR
title check.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
