### PR TITLE
feat(x509): add SubjectInfoAccess and SubjectDirectoryAttributes extensions

### DIFF
--- a/x509/src/extensions/error.rs
+++ b/x509/src/extensions/error.rs
@@ -21,6 +21,7 @@ pub enum Kind {
     PolicyConstraints,
     PolicyMappings,
     SubjectInfoAccess,
+    SubjectDirectoryAttributes,
 }
 
 impl std::fmt::Display for Kind {
@@ -42,6 +43,7 @@ impl std::fmt::Display for Kind {
             Self::PolicyConstraints => write!(f, "PolicyConstraints"),
             Self::PolicyMappings => write!(f, "PolicyMappings"),
             Self::SubjectInfoAccess => write!(f, "SubjectInfoAccess"),
+            Self::SubjectDirectoryAttributes => write!(f, "SubjectDirectoryAttributes"),
         }
     }
 }
@@ -237,6 +239,22 @@ pub enum Error {
 
     #[error("SubjectInfoAccess: accessMethod must be OBJECT IDENTIFIER")]
     SubjectInfoAccessExpectedOid,
+
+    // SubjectDirectoryAttributes specific errors
+    #[error("SubjectDirectoryAttributes: at least one Attribute required")]
+    SubjectDirectoryAttributesEmpty,
+
+    #[error("SubjectDirectoryAttributes: Attribute must be SEQUENCE with 2 elements")]
+    SubjectDirectoryAttributeInvalidStructure,
+
+    #[error("SubjectDirectoryAttributes: type must be OBJECT IDENTIFIER")]
+    SubjectDirectoryAttributeExpectedOid,
+
+    #[error("SubjectDirectoryAttributes: values must be SET")]
+    SubjectDirectoryAttributeExpectedSet,
+
+    #[error("SubjectDirectoryAttributes: at least one AttributeValue required")]
+    SubjectDirectoryAttributeEmptyValues,
 
     /// Invalid ASN.1 structure
     #[error("invalid ASN.1: {0}")]

--- a/x509/src/extensions/error.rs
+++ b/x509/src/extensions/error.rs
@@ -20,6 +20,7 @@ pub enum Kind {
     InhibitAnyPolicy,
     PolicyConstraints,
     PolicyMappings,
+    SubjectInfoAccess,
 }
 
 impl std::fmt::Display for Kind {
@@ -40,6 +41,7 @@ impl std::fmt::Display for Kind {
             Self::InhibitAnyPolicy => write!(f, "InhibitAnyPolicy"),
             Self::PolicyConstraints => write!(f, "PolicyConstraints"),
             Self::PolicyMappings => write!(f, "PolicyMappings"),
+            Self::SubjectInfoAccess => write!(f, "SubjectInfoAccess"),
         }
     }
 }
@@ -225,6 +227,16 @@ pub enum Error {
 
     #[error("AuthorityInfoAccess: accessMethod must be OBJECT IDENTIFIER")]
     AccessDescriptionExpectedOid,
+
+    // SubjectInfoAccess specific errors
+    #[error("SubjectInfoAccess: at least one AccessDescription required")]
+    SubjectInfoAccessEmpty,
+
+    #[error("SubjectInfoAccess: AccessDescription must be SEQUENCE with 2 elements")]
+    SubjectInfoAccessInvalidStructure,
+
+    #[error("SubjectInfoAccess: accessMethod must be OBJECT IDENTIFIER")]
+    SubjectInfoAccessExpectedOid,
 
     /// Invalid ASN.1 structure
     #[error("invalid ASN.1: {0}")]

--- a/x509/src/extensions/mod.rs
+++ b/x509/src/extensions/mod.rs
@@ -125,7 +125,6 @@ impl tsumiki_pkix_types::OidName for RawExtension {
             AuthorityInfoAccess::OID => Some("authorityInfoAccess"),
             // Additional common extensions not yet implemented
             "2.5.29.9" => Some("subjectDirectoryAttributes"),
-            "2.5.29.16" => Some("privateKeyUsagePeriod"),
             "1.3.6.1.5.5.7.1.11" => Some("subjectInfoAccess"),
             _ => None,
         }

--- a/x509/src/extensions/mod.rs
+++ b/x509/src/extensions/mod.rs
@@ -29,6 +29,7 @@ mod name_constraints;
 mod policy_constraints;
 mod policy_mappings;
 mod subject_alt_name;
+mod subject_directory_attributes;
 mod subject_info_access;
 mod subject_key_identifier;
 
@@ -53,6 +54,7 @@ pub use name_constraints::{GeneralSubtree, NameConstraints};
 pub use policy_constraints::{PolicyConstraints, SkipCerts};
 pub use policy_mappings::{PolicyMapping, PolicyMappings};
 pub use subject_alt_name::SubjectAltName;
+pub use subject_directory_attributes::{SubjectDirectoryAttribute, SubjectDirectoryAttributes};
 pub use subject_info_access::SubjectInfoAccess;
 pub use subject_key_identifier::SubjectKeyIdentifier;
 use tsumiki_asn1::AsOid;
@@ -125,9 +127,8 @@ impl tsumiki_pkix_types::OidName for RawExtension {
             FreshestCRL::OID => Some("freshestCRL"),
             InhibitAnyPolicy::OID => Some("inhibitAnyPolicy"),
             AuthorityInfoAccess::OID => Some("authorityInfoAccess"),
-            // Additional common extensions not yet implemented
-            "2.5.29.9" => Some("subjectDirectoryAttributes"),
             SubjectInfoAccess::OID => Some("subjectInfoAccess"),
+            SubjectDirectoryAttributes::OID => Some("subjectDirectoryAttributes"),
             _ => None,
         }
     }
@@ -390,6 +391,10 @@ pub(crate) struct ParsedExtensions {
     pub(crate) freshest_crl: Option<FreshestCRL>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) subject_info_access: Option<SubjectInfoAccess>,
+    // SubjectDirectoryAttributes currently has no Serialize impl because
+    // AttributeValue is held as raw asn1 Element; skip it in JSON output.
+    #[serde(skip)]
+    pub(crate) subject_directory_attributes: Option<SubjectDirectoryAttributes>,
 }
 
 impl ParsedExtensions {
@@ -411,6 +416,7 @@ impl ParsedExtensions {
             inhibit_any_policy: None,
             freshest_crl: None,
             subject_info_access: None,
+            subject_directory_attributes: None,
         };
 
         for ext in extensions.extensions() {
@@ -462,6 +468,10 @@ impl ParsedExtensions {
                 }
                 SubjectInfoAccess::OID => {
                     raw.subject_info_access = Some(ext.parse::<SubjectInfoAccess>()?);
+                }
+                SubjectDirectoryAttributes::OID => {
+                    raw.subject_directory_attributes =
+                        Some(ext.parse::<SubjectDirectoryAttributes>()?);
                 }
                 _ => {
                     // Unknown extension, skip

--- a/x509/src/extensions/mod.rs
+++ b/x509/src/extensions/mod.rs
@@ -29,6 +29,7 @@ mod name_constraints;
 mod policy_constraints;
 mod policy_mappings;
 mod subject_alt_name;
+mod subject_info_access;
 mod subject_key_identifier;
 
 // Re-export public types
@@ -52,6 +53,7 @@ pub use name_constraints::{GeneralSubtree, NameConstraints};
 pub use policy_constraints::{PolicyConstraints, SkipCerts};
 pub use policy_mappings::{PolicyMapping, PolicyMappings};
 pub use subject_alt_name::SubjectAltName;
+pub use subject_info_access::SubjectInfoAccess;
 pub use subject_key_identifier::SubjectKeyIdentifier;
 use tsumiki_asn1::AsOid;
 
@@ -125,7 +127,7 @@ impl tsumiki_pkix_types::OidName for RawExtension {
             AuthorityInfoAccess::OID => Some("authorityInfoAccess"),
             // Additional common extensions not yet implemented
             "2.5.29.9" => Some("subjectDirectoryAttributes"),
-            "1.3.6.1.5.5.7.1.11" => Some("subjectInfoAccess"),
+            SubjectInfoAccess::OID => Some("subjectInfoAccess"),
             _ => None,
         }
     }
@@ -386,6 +388,8 @@ pub(crate) struct ParsedExtensions {
     pub(crate) inhibit_any_policy: Option<InhibitAnyPolicy>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) freshest_crl: Option<FreshestCRL>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) subject_info_access: Option<SubjectInfoAccess>,
 }
 
 impl ParsedExtensions {
@@ -406,6 +410,7 @@ impl ParsedExtensions {
             policy_constraints: None,
             inhibit_any_policy: None,
             freshest_crl: None,
+            subject_info_access: None,
         };
 
         for ext in extensions.extensions() {
@@ -454,6 +459,9 @@ impl ParsedExtensions {
                 }
                 FreshestCRL::OID => {
                     raw.freshest_crl = Some(ext.parse::<FreshestCRL>()?);
+                }
+                SubjectInfoAccess::OID => {
+                    raw.subject_info_access = Some(ext.parse::<SubjectInfoAccess>()?);
                 }
                 _ => {
                     // Unknown extension, skip

--- a/x509/src/extensions/subject_directory_attributes.rs
+++ b/x509/src/extensions/subject_directory_attributes.rs
@@ -1,0 +1,469 @@
+use std::fmt;
+use tsumiki::decoder::{DecodableFrom, Decoder};
+use tsumiki::encoder::{EncodableTo, Encoder};
+use tsumiki_asn1::{ASN1Object, Element, ObjectIdentifier, OctetString};
+use tsumiki_pkix_types::OidName;
+
+use super::error;
+use crate::error::Error;
+use crate::extensions::Extension;
+
+/*
+RFC 5280 Section 4.2.1.8: Subject Directory Attributes
+https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.8
+
+id-ce-subjectDirectoryAttributes OBJECT IDENTIFIER ::= { id-ce 9 }
+
+SubjectDirectoryAttributes ::= SEQUENCE SIZE (1..MAX) OF AttributeSet{{SupportedAttributes}}
+
+AttributeSet ::= SEQUENCE {
+    type      AttributeType,
+    values    SET OF AttributeValue
+}
+
+`AttributeSet` is named `SubjectDirectoryAttribute` here to avoid name collision
+with a potential future `tsumiki_pkix_types::Attribute` lifted from PKCS#9.
+*/
+
+/// A single X.509 Subject Directory Attribute (RFC 5280 §4.2.1.8 / Appendix A `Attribute`).
+///
+/// ASN.1 (RFC 5280 Appendix A.1, PKIX1Explicit88):
+/// ```text
+/// Attribute ::= SEQUENCE {
+///     type    AttributeType,
+///     values  SET OF AttributeValue
+///         -- at least one value is required
+/// }
+/// AttributeType  ::= OBJECT IDENTIFIER
+/// AttributeValue ::= ANY -- DEFINED BY AttributeType
+/// ```
+///
+/// `attribute_type` corresponds to the ASN.1 `type` field (renamed because
+/// `type` is a Rust reserved keyword). `values` is stored as raw [`Element`]
+/// since RFC 5280 does not constrain the value type beyond `ANY DEFINED BY type`.
+/// Helper methods to project well-known OIDs (e.g. RFC 3739 `dateOfBirth`) onto
+/// typed values are intentionally out of scope here.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubjectDirectoryAttribute {
+    pub attribute_type: ObjectIdentifier,
+    pub values: Vec<Element>,
+}
+
+impl DecodableFrom<Element> for SubjectDirectoryAttribute {}
+
+impl Decoder<Element, SubjectDirectoryAttribute> for Element {
+    type Error = Error;
+
+    fn decode(&self) -> Result<SubjectDirectoryAttribute, Self::Error> {
+        match self {
+            Element::Sequence(elements) => match elements.as_slice() {
+                [Element::ObjectIdentifier(oid), Element::Set(values)] => {
+                    if values.is_empty() {
+                        return Err(error::Error::SubjectDirectoryAttributeEmptyValues.into());
+                    }
+                    Ok(SubjectDirectoryAttribute {
+                        attribute_type: oid.clone(),
+                        values: values.clone(),
+                    })
+                }
+                [Element::ObjectIdentifier(_), _] => {
+                    Err(error::Error::SubjectDirectoryAttributeExpectedSet.into())
+                }
+                [_, _] => Err(error::Error::SubjectDirectoryAttributeExpectedOid.into()),
+                _ => Err(error::Error::SubjectDirectoryAttributeInvalidStructure.into()),
+            },
+            _ => {
+                Err(error::Error::ExpectedSequence(error::Kind::SubjectDirectoryAttributes).into())
+            }
+        }
+    }
+}
+
+impl EncodableTo<SubjectDirectoryAttribute> for Element {}
+
+impl Encoder<SubjectDirectoryAttribute, Element> for SubjectDirectoryAttribute {
+    type Error = Error;
+
+    fn encode(&self) -> Result<Element, Self::Error> {
+        if self.values.is_empty() {
+            return Err(error::Error::SubjectDirectoryAttributeEmptyValues.into());
+        }
+
+        // DER requires SET OF elements to be sorted by their encoded byte
+        // representation (X.690 §11.6). The asn1 crate's `Element::Set` encoder
+        // does not currently sort, so we sort here before constructing the SET.
+        let sorted_values = sort_set_elements(&self.values)?;
+
+        Ok(Element::Sequence(vec![
+            Element::ObjectIdentifier(self.attribute_type.clone()),
+            Element::Set(sorted_values),
+        ]))
+    }
+}
+
+/// Sort SET OF elements by their DER-encoded byte representation per X.690 §11.6.
+fn sort_set_elements(values: &[Element]) -> Result<Vec<Element>, Error> {
+    let mut encoded_pairs: Vec<(Vec<u8>, Element)> = values
+        .iter()
+        .map(|elem| {
+            let tlv: tsumiki_der::Tlv = elem.encode().map_err(Error::InvalidASN1)?;
+            let bytes: Vec<u8> = tlv.encode()?;
+            Ok((bytes, elem.clone()))
+        })
+        .collect::<Result<Vec<_>, Error>>()?;
+    encoded_pairs.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(encoded_pairs.into_iter().map(|(_, elem)| elem).collect())
+}
+
+/// Subject Directory Attributes extension ([RFC 5280 §4.2.1.8](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.1.8)).
+///
+/// MUST be marked non-critical per RFC 5280.
+///
+/// Serialization (serde) is not currently implemented because `AttributeValue`
+/// is held as a raw [`Element`], which does not implement `Serialize`. Until
+/// that is addressed, this extension is omitted from JSON / YAML output of
+/// `ParsedExtensions` (see the project's "今後の課題" — Element serde support).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SubjectDirectoryAttributes {
+    pub attributes: Vec<SubjectDirectoryAttribute>,
+}
+
+impl SubjectDirectoryAttributes {
+    /// Date of Birth attribute (RFC 3739 §5)
+    /// OID: 1.3.6.1.5.5.7.9.1
+    pub const DATE_OF_BIRTH: &'static str = "1.3.6.1.5.5.7.9.1";
+
+    /// Place of Birth attribute (RFC 3739 §5)
+    /// OID: 1.3.6.1.5.5.7.9.2
+    pub const PLACE_OF_BIRTH: &'static str = "1.3.6.1.5.5.7.9.2";
+
+    /// Gender attribute (RFC 3739 §5)
+    /// OID: 1.3.6.1.5.5.7.9.3
+    pub const GENDER: &'static str = "1.3.6.1.5.5.7.9.3";
+
+    /// Country of Citizenship attribute (RFC 3739 §5)
+    /// OID: 1.3.6.1.5.5.7.9.4
+    pub const COUNTRY_OF_CITIZENSHIP: &'static str = "1.3.6.1.5.5.7.9.4";
+
+    /// Country of Residence attribute (RFC 3739 §5)
+    /// OID: 1.3.6.1.5.5.7.9.5
+    pub const COUNTRY_OF_RESIDENCE: &'static str = "1.3.6.1.5.5.7.9.5";
+}
+
+impl DecodableFrom<OctetString> for SubjectDirectoryAttributes {}
+
+impl Decoder<OctetString, SubjectDirectoryAttributes> for OctetString {
+    type Error = Error;
+
+    fn decode(&self) -> Result<SubjectDirectoryAttributes, Self::Error> {
+        let asn1_obj = ASN1Object::try_from(self).map_err(Error::InvalidASN1)?;
+
+        match asn1_obj.elements() {
+            [elem, ..] => elem.decode(),
+            [] => Err(error::Error::SubjectDirectoryAttributesEmpty.into()),
+        }
+    }
+}
+
+impl DecodableFrom<Element> for SubjectDirectoryAttributes {}
+
+impl Decoder<Element, SubjectDirectoryAttributes> for Element {
+    type Error = Error;
+
+    fn decode(&self) -> Result<SubjectDirectoryAttributes, Self::Error> {
+        match self {
+            Element::Sequence(elements) => {
+                if elements.is_empty() {
+                    return Err(error::Error::SubjectDirectoryAttributesEmpty.into());
+                }
+
+                let attributes = elements
+                    .iter()
+                    .map(|elem| elem.decode())
+                    .collect::<Result<Vec<SubjectDirectoryAttribute>, _>>()?;
+
+                Ok(SubjectDirectoryAttributes { attributes })
+            }
+            _ => {
+                Err(error::Error::ExpectedSequence(error::Kind::SubjectDirectoryAttributes).into())
+            }
+        }
+    }
+}
+
+impl EncodableTo<SubjectDirectoryAttributes> for Element {}
+
+impl Encoder<SubjectDirectoryAttributes, Element> for SubjectDirectoryAttributes {
+    type Error = Error;
+
+    fn encode(&self) -> Result<Element, Self::Error> {
+        if self.attributes.is_empty() {
+            return Err(error::Error::SubjectDirectoryAttributesEmpty.into());
+        }
+
+        let attr_elements = self
+            .attributes
+            .iter()
+            .map(|attr| attr.encode())
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Element::Sequence(attr_elements))
+    }
+}
+
+impl Extension for SubjectDirectoryAttributes {
+    /// OID for SubjectDirectoryAttributes extension (2.5.29.9)
+    const OID: &'static str = "2.5.29.9";
+
+    fn parse(value: &OctetString) -> Result<Self, Error> {
+        value.decode()
+    }
+}
+
+impl OidName for SubjectDirectoryAttributes {
+    fn oid_name(&self) -> Option<&'static str> {
+        Some("subjectDirectoryAttributes")
+    }
+}
+
+impl fmt::Display for SubjectDirectoryAttributes {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ext_name = self.oid_name().unwrap_or("subjectDirectoryAttributes");
+        writeln!(f, "            X509v3 {}:", ext_name)?;
+        for attr in &self.attributes {
+            let attr_name = match attr.attribute_type.to_string().as_str() {
+                Self::DATE_OF_BIRTH => "Date of Birth",
+                Self::PLACE_OF_BIRTH => "Place of Birth",
+                Self::GENDER => "Gender",
+                Self::COUNTRY_OF_CITIZENSHIP => "Country of Citizenship",
+                Self::COUNTRY_OF_RESIDENCE => "Country of Residence",
+                _ => "Unknown",
+            };
+            let values_str = attr
+                .values
+                .iter()
+                .map(|v| v.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            writeln!(f, "                {} - {}", attr_name, values_str)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extensions::RawExtension;
+    use chrono::NaiveDate;
+    use rstest::rstest;
+    use std::str::FromStr;
+
+    // RFC 3739 §5 OIDs used in tests
+    const DATE_OF_BIRTH: &str = "1.3.6.1.5.5.7.9.1";
+    const COUNTRY_OF_CITIZENSHIP: &str = "1.3.6.1.5.5.7.9.4";
+
+    fn date_of_birth_element() -> Element {
+        Element::GeneralizedTime(
+            NaiveDate::from_ymd_opt(1990, 1, 1)
+                .unwrap()
+                .and_hms_opt(0, 0, 0)
+                .unwrap(),
+        )
+    }
+
+    fn country_element(country: &str) -> Element {
+        Element::PrintableString(country.to_string())
+    }
+
+    #[rstest]
+    #[case(
+        // Single attribute: dateOfBirth (RFC 3739)
+        Element::Sequence(vec![
+            Element::Sequence(vec![
+                Element::ObjectIdentifier(ObjectIdentifier::from_str(DATE_OF_BIRTH).unwrap()),
+                Element::Set(vec![date_of_birth_element()]),
+            ]),
+        ]),
+        vec![SubjectDirectoryAttribute {
+            attribute_type: ObjectIdentifier::from_str(DATE_OF_BIRTH).unwrap(),
+            values: vec![date_of_birth_element()],
+        }]
+    )]
+    #[case(
+        // Single attribute: countryOfCitizenship (RFC 3739)
+        Element::Sequence(vec![
+            Element::Sequence(vec![
+                Element::ObjectIdentifier(ObjectIdentifier::from_str(COUNTRY_OF_CITIZENSHIP).unwrap()),
+                Element::Set(vec![country_element("JP")]),
+            ]),
+        ]),
+        vec![SubjectDirectoryAttribute {
+            attribute_type: ObjectIdentifier::from_str(COUNTRY_OF_CITIZENSHIP).unwrap(),
+            values: vec![country_element("JP")],
+        }]
+    )]
+    #[case(
+        // Multiple attributes
+        Element::Sequence(vec![
+            Element::Sequence(vec![
+                Element::ObjectIdentifier(ObjectIdentifier::from_str(DATE_OF_BIRTH).unwrap()),
+                Element::Set(vec![date_of_birth_element()]),
+            ]),
+            Element::Sequence(vec![
+                Element::ObjectIdentifier(ObjectIdentifier::from_str(COUNTRY_OF_CITIZENSHIP).unwrap()),
+                Element::Set(vec![country_element("US")]),
+            ]),
+        ]),
+        vec![
+            SubjectDirectoryAttribute {
+                attribute_type: ObjectIdentifier::from_str(DATE_OF_BIRTH).unwrap(),
+                values: vec![date_of_birth_element()],
+            },
+            SubjectDirectoryAttribute {
+                attribute_type: ObjectIdentifier::from_str(COUNTRY_OF_CITIZENSHIP).unwrap(),
+                values: vec![country_element("US")],
+            },
+        ]
+    )]
+    fn test_subject_directory_attributes_decode_success(
+        #[case] input: Element,
+        #[case] expected_attrs: Vec<SubjectDirectoryAttribute>,
+    ) {
+        let result: Result<SubjectDirectoryAttributes, Error> = input.decode();
+        let sda = result.expect("decode failed");
+        assert_eq!(sda.attributes, expected_attrs);
+    }
+
+    #[rstest]
+    #[case(Element::Sequence(vec![]))]
+    fn test_subject_directory_attributes_decode_empty(#[case] input: Element) {
+        let result: Result<SubjectDirectoryAttributes, Error> = input.decode();
+        assert!(matches!(
+            result,
+            Err(Error::ExtensionError(
+                error::Error::SubjectDirectoryAttributesEmpty
+            ))
+        ));
+    }
+
+    #[rstest]
+    #[case(Element::Sequence(vec![
+        Element::Sequence(vec![
+            Element::ObjectIdentifier(ObjectIdentifier::from_str(DATE_OF_BIRTH).unwrap()),
+            // values is not a SET
+            Element::OctetString(OctetString::from(vec![0x01])),
+        ]),
+    ]))]
+    fn test_subject_directory_attributes_decode_values_not_set(#[case] input: Element) {
+        let result: Result<SubjectDirectoryAttributes, Error> = input.decode();
+        assert!(matches!(
+            result,
+            Err(Error::ExtensionError(
+                error::Error::SubjectDirectoryAttributeExpectedSet
+            ))
+        ));
+    }
+
+    #[rstest]
+    #[case(Element::Sequence(vec![
+        Element::Sequence(vec![
+            // attribute_type is not OID
+            Element::OctetString(OctetString::from(vec![0x01])),
+            Element::Set(vec![country_element("JP")]),
+        ]),
+    ]))]
+    fn test_subject_directory_attributes_decode_type_not_oid(#[case] input: Element) {
+        let result: Result<SubjectDirectoryAttributes, Error> = input.decode();
+        assert!(matches!(
+            result,
+            Err(Error::ExtensionError(
+                error::Error::SubjectDirectoryAttributeExpectedOid
+            ))
+        ));
+    }
+
+    #[rstest]
+    #[case(Element::Sequence(vec![
+        Element::Sequence(vec![
+            Element::ObjectIdentifier(ObjectIdentifier::from_str(COUNTRY_OF_CITIZENSHIP).unwrap()),
+            // empty SET
+            Element::Set(vec![]),
+        ]),
+    ]))]
+    fn test_subject_directory_attributes_decode_empty_values(#[case] input: Element) {
+        let result: Result<SubjectDirectoryAttributes, Error> = input.decode();
+        assert!(matches!(
+            result,
+            Err(Error::ExtensionError(
+                error::Error::SubjectDirectoryAttributeEmptyValues
+            ))
+        ));
+    }
+
+    #[rstest]
+    #[case(SubjectDirectoryAttributes {
+        attributes: vec![
+            SubjectDirectoryAttribute {
+                attribute_type: ObjectIdentifier::from_str(COUNTRY_OF_CITIZENSHIP).unwrap(),
+                values: vec![country_element("JP")],
+            },
+        ],
+    })]
+    #[case(SubjectDirectoryAttributes {
+        attributes: vec![
+            SubjectDirectoryAttribute {
+                attribute_type: ObjectIdentifier::from_str(DATE_OF_BIRTH).unwrap(),
+                values: vec![date_of_birth_element()],
+            },
+            SubjectDirectoryAttribute {
+                attribute_type: ObjectIdentifier::from_str(COUNTRY_OF_CITIZENSHIP).unwrap(),
+                values: vec![country_element("US")],
+            },
+        ],
+    })]
+    fn test_subject_directory_attributes_encode_decode(
+        #[case] original: SubjectDirectoryAttributes,
+    ) {
+        let encoded = original.encode().expect("encode failed");
+        let decoded: SubjectDirectoryAttributes = encoded.decode().expect("decode failed");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_subject_directory_attributes_parse_from_extension() {
+        // Build a SubjectDirectoryAttributes value, encode it to DER, then parse
+        // it back via the Extension trait (the same path Certificate parsing uses).
+        let original = SubjectDirectoryAttributes {
+            attributes: vec![SubjectDirectoryAttribute {
+                attribute_type: ObjectIdentifier::from_str(COUNTRY_OF_CITIZENSHIP).unwrap(),
+                values: vec![country_element("JP")],
+            }],
+        };
+        let encoded_elem = original.encode().expect("encode failed");
+        let tlv: tsumiki_der::Tlv = encoded_elem.encode().expect("tlv encode failed");
+        let der_bytes: Vec<u8> = tlv.encode().expect("der encode failed");
+
+        let extension = RawExtension::new(
+            ObjectIdentifier::from_str(SubjectDirectoryAttributes::OID).unwrap(),
+            false,
+            OctetString::from(der_bytes),
+        );
+
+        let parsed = extension
+            .parse::<SubjectDirectoryAttributes>()
+            .expect("parse failed");
+        assert_eq!(parsed, original);
+    }
+
+    #[test]
+    fn test_set_of_elements_sorted_on_encode() {
+        // Two PrintableString values intentionally provided out of DER sort order.
+        // The encoder should sort them by encoded bytes (X.690 §11.6).
+        let unsorted = vec![country_element("JP"), country_element("CA")];
+        let sorted = sort_set_elements(&unsorted).expect("sort failed");
+
+        // PrintableString tag is 0x13; "CA" < "JP" lexicographically.
+        // After sorting we expect ["CA", "JP"].
+        assert_eq!(sorted, vec![country_element("CA"), country_element("JP")]);
+    }
+}

--- a/x509/src/extensions/subject_info_access.rs
+++ b/x509/src/extensions/subject_info_access.rs
@@ -1,0 +1,390 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use tsumiki::decoder::{DecodableFrom, Decoder};
+use tsumiki::encoder::{EncodableTo, Encoder};
+use tsumiki_asn1::{ASN1Object, Element, OctetString};
+use tsumiki_pkix_types::OidName;
+
+use super::error;
+use crate::error::Error;
+use crate::extensions::general_name::GeneralName;
+use crate::extensions::{AccessDescription, Extension};
+
+/*
+RFC 5280 Section 4.2.2.2: Subject Information Access
+https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.2.2
+
+id-pe-subjectInfoAccess OBJECT IDENTIFIER ::= { id-pe 11 }
+SubjectInfoAccessSyntax  ::= SEQUENCE SIZE (1..MAX) OF AccessDescription
+
+AccessDescription  ::=  SEQUENCE {
+    accessMethod          OBJECT IDENTIFIER,
+    accessLocation        GeneralName
+}
+
+id-ad-caRepository  OBJECT IDENTIFIER ::= { id-ad 5 }
+id-ad-timeStamping  OBJECT IDENTIFIER ::= { id-ad 3 }
+*/
+
+/// Subject Information Access extension ([RFC 5280 §4.2.2.2](https://datatracker.ietf.org/doc/html/rfc5280#section-4.2.2.2)).
+///
+/// Conveys information about how to access additional information about the
+/// subject of the certificate (typically the subordinate CA's repository or
+/// a timestamping service).
+///
+/// MUST be marked non-critical per RFC 5280.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SubjectInfoAccess {
+    pub descriptors: Vec<AccessDescription>,
+}
+
+impl SubjectInfoAccess {
+    /// CA Repository access method (id-ad-caRepository)
+    /// OID: 1.3.6.1.5.5.7.48.5
+    pub const CA_REPOSITORY: &'static str = "1.3.6.1.5.5.7.48.5";
+
+    /// Time Stamping access method (id-ad-timeStamping)
+    /// OID: 1.3.6.1.5.5.7.48.3
+    pub const TIME_STAMPING: &'static str = "1.3.6.1.5.5.7.48.3";
+}
+
+impl DecodableFrom<OctetString> for SubjectInfoAccess {}
+
+impl Decoder<OctetString, SubjectInfoAccess> for OctetString {
+    type Error = Error;
+
+    fn decode(&self) -> Result<SubjectInfoAccess, Self::Error> {
+        let asn1_obj = ASN1Object::try_from(self).map_err(Error::InvalidASN1)?;
+
+        match asn1_obj.elements() {
+            [elem, ..] => elem.decode(),
+            [] => Err(error::Error::SubjectInfoAccessEmpty.into()),
+        }
+    }
+}
+
+impl DecodableFrom<Element> for SubjectInfoAccess {}
+
+// AccessDescription is shared with AuthorityInfoAccess as a type (RFC 5280 §4.2.2.1
+// and §4.2.2.2 use the identical SEQUENCE), but its decoding is duplicated here so
+// that error variants reference SubjectInfoAccess rather than AuthorityInfoAccess.
+// This mirrors the existing crate pattern where each extension owns its own
+// decode/error wiring (cf. `general_name.rs`).
+fn decode_access_description(elem: &Element) -> Result<AccessDescription, Error> {
+    match elem {
+        Element::Sequence(elements) => match elements.as_slice() {
+            [Element::ObjectIdentifier(oid), location_elem] => {
+                let access_location: GeneralName = location_elem.decode()?;
+                Ok(AccessDescription {
+                    access_method: oid.clone(),
+                    access_location,
+                })
+            }
+            [_, _] => Err(error::Error::SubjectInfoAccessExpectedOid.into()),
+            _ => Err(error::Error::SubjectInfoAccessInvalidStructure.into()),
+        },
+        _ => Err(error::Error::ExpectedSequence(error::Kind::SubjectInfoAccess).into()),
+    }
+}
+
+impl Decoder<Element, SubjectInfoAccess> for Element {
+    type Error = Error;
+
+    fn decode(&self) -> Result<SubjectInfoAccess, Self::Error> {
+        match self {
+            Element::Sequence(elements) => {
+                if elements.is_empty() {
+                    return Err(error::Error::SubjectInfoAccessEmpty.into());
+                }
+
+                let descriptors = elements
+                    .iter()
+                    .map(decode_access_description)
+                    .collect::<Result<Vec<AccessDescription>, _>>()?;
+
+                Ok(SubjectInfoAccess { descriptors })
+            }
+            _ => Err(error::Error::ExpectedSequence(error::Kind::SubjectInfoAccess).into()),
+        }
+    }
+}
+
+impl EncodableTo<SubjectInfoAccess> for Element {}
+
+impl Encoder<SubjectInfoAccess, Element> for SubjectInfoAccess {
+    type Error = Error;
+
+    fn encode(&self) -> Result<Element, Self::Error> {
+        if self.descriptors.is_empty() {
+            return Err(error::Error::SubjectInfoAccessEmpty.into());
+        }
+
+        let desc_elements = self
+            .descriptors
+            .iter()
+            .map(|desc| desc.encode())
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Element::Sequence(desc_elements))
+    }
+}
+
+impl Extension for SubjectInfoAccess {
+    /// OID for SubjectInfoAccess extension (1.3.6.1.5.5.7.1.11)
+    const OID: &'static str = "1.3.6.1.5.5.7.1.11";
+
+    fn parse(value: &OctetString) -> Result<Self, Error> {
+        value.decode()
+    }
+}
+
+impl OidName for SubjectInfoAccess {
+    fn oid_name(&self) -> Option<&'static str> {
+        Some("subjectInfoAccess")
+    }
+}
+
+impl fmt::Display for SubjectInfoAccess {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let ext_name = self.oid_name().unwrap_or("subjectInfoAccess");
+        writeln!(f, "            X509v3 {}:", ext_name)?;
+        for desc in &self.descriptors {
+            let method = match desc.access_method.to_string().as_str() {
+                Self::CA_REPOSITORY => "CA Repository",
+                Self::TIME_STAMPING => "Time Stamping",
+                _ => "Unknown",
+            };
+            writeln!(f, "                {} - {}", method, desc.access_location)?;
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extensions::RawExtension;
+    use crate::extensions::general_name::GeneralName;
+    use rstest::rstest;
+    use std::str::FromStr;
+    use tsumiki_asn1::ObjectIdentifier;
+
+    #[rstest(input, expected)]
+    #[case(
+        Element::Sequence(vec![
+            Element::Sequence(vec![
+                Element::ObjectIdentifier(ObjectIdentifier::from_str(SubjectInfoAccess::CA_REPOSITORY).unwrap()),
+                Element::ContextSpecific {
+                    constructed: false,
+                    slot: 6,
+                    element: Box::new(Element::OctetString(OctetString::from(b"http://ca.example.com/repo".to_vec()))),
+                },
+            ]),
+        ]),
+        SubjectInfoAccess {
+            descriptors: vec![AccessDescription {
+                access_method: ObjectIdentifier::from_str(SubjectInfoAccess::CA_REPOSITORY).unwrap(),
+                access_location: GeneralName::Uri("http://ca.example.com/repo".to_string()),
+            }],
+        }
+    )]
+    #[case(
+        Element::Sequence(vec![
+            Element::Sequence(vec![
+                Element::ObjectIdentifier(ObjectIdentifier::from_str(SubjectInfoAccess::TIME_STAMPING).unwrap()),
+                Element::ContextSpecific {
+                    constructed: false,
+                    slot: 6,
+                    element: Box::new(Element::OctetString(OctetString::from(b"http://tsa.example.com".to_vec()))),
+                },
+            ]),
+        ]),
+        SubjectInfoAccess {
+            descriptors: vec![AccessDescription {
+                access_method: ObjectIdentifier::from_str(SubjectInfoAccess::TIME_STAMPING).unwrap(),
+                access_location: GeneralName::Uri("http://tsa.example.com".to_string()),
+            }],
+        }
+    )]
+    #[case(
+        Element::Sequence(vec![
+            Element::Sequence(vec![
+                Element::ObjectIdentifier(ObjectIdentifier::from_str(SubjectInfoAccess::CA_REPOSITORY).unwrap()),
+                Element::ContextSpecific {
+                    constructed: false,
+                    slot: 6,
+                    element: Box::new(Element::OctetString(OctetString::from(b"http://ca.example.com/repo".to_vec()))),
+                },
+            ]),
+            Element::Sequence(vec![
+                Element::ObjectIdentifier(ObjectIdentifier::from_str(SubjectInfoAccess::TIME_STAMPING).unwrap()),
+                Element::ContextSpecific {
+                    constructed: false,
+                    slot: 6,
+                    element: Box::new(Element::OctetString(OctetString::from(b"http://tsa.example.com".to_vec()))),
+                },
+            ]),
+        ]),
+        SubjectInfoAccess {
+            descriptors: vec![
+                AccessDescription {
+                    access_method: ObjectIdentifier::from_str(SubjectInfoAccess::CA_REPOSITORY).unwrap(),
+                    access_location: GeneralName::Uri("http://ca.example.com/repo".to_string()),
+                },
+                AccessDescription {
+                    access_method: ObjectIdentifier::from_str(SubjectInfoAccess::TIME_STAMPING).unwrap(),
+                    access_location: GeneralName::Uri("http://tsa.example.com".to_string()),
+                },
+            ],
+        }
+    )]
+    #[case(
+        Element::Sequence(vec![
+            Element::Sequence(vec![
+                Element::ObjectIdentifier(ObjectIdentifier::from_str("1.3.6.1.5.5.7.48.99").unwrap()),
+                Element::ContextSpecific {
+                    constructed: false,
+                    slot: 2,
+                    element: Box::new(Element::OctetString(OctetString::from(b"info.example.com".to_vec()))),
+                },
+            ]),
+        ]),
+        SubjectInfoAccess {
+            descriptors: vec![AccessDescription {
+                access_method: ObjectIdentifier::from_str("1.3.6.1.5.5.7.48.99").unwrap(),
+                access_location: GeneralName::DnsName("info.example.com".to_string()),
+            }],
+        }
+    )]
+    fn test_subject_info_access_decode_success(input: Element, expected: SubjectInfoAccess) {
+        let result: Result<SubjectInfoAccess, Error> = input.decode();
+        assert!(result.is_ok(), "Failed to decode: {:?}", result);
+        assert_eq!(expected, result.unwrap());
+    }
+
+    #[rstest]
+    #[case(Element::Sequence(vec![]))]
+    fn test_subject_info_access_decode_empty(#[case] input: Element) {
+        let result: Result<SubjectInfoAccess, Error> = input.decode();
+        assert!(matches!(
+            result,
+            Err(Error::ExtensionError(error::Error::SubjectInfoAccessEmpty))
+        ));
+    }
+
+    #[rstest]
+    #[case(Element::Sequence(vec![
+        Element::Sequence(vec![
+            Element::OctetString(OctetString::from(vec![0x01])),
+            Element::ContextSpecific {
+                constructed: false,
+                slot: 6,
+                element: Box::new(Element::OctetString(OctetString::from(b"http://example.com".to_vec()))),
+            },
+        ]),
+    ]))]
+    fn test_subject_info_access_decode_method_not_oid(#[case] input: Element) {
+        let result: Result<SubjectInfoAccess, Error> = input.decode();
+        assert!(matches!(
+            result,
+            Err(Error::ExtensionError(
+                error::Error::SubjectInfoAccessExpectedOid
+            ))
+        ));
+    }
+
+    #[rstest]
+    #[case(Element::OctetString(OctetString::from(vec![0x01, 0x02])))]
+    fn test_subject_info_access_decode_not_sequence(#[case] input: Element) {
+        let result: Result<SubjectInfoAccess, Error> = input.decode();
+        assert!(matches!(
+            result,
+            Err(Error::ExtensionError(error::Error::ExpectedSequence(
+                error::Kind::SubjectInfoAccess
+            )))
+        ));
+    }
+
+    #[rstest]
+    #[case(SubjectInfoAccess {
+        descriptors: vec![
+            AccessDescription {
+                access_method: ObjectIdentifier::from_str(SubjectInfoAccess::CA_REPOSITORY).unwrap(),
+                access_location: GeneralName::Uri("http://ca.example.com/repo".to_string()),
+            },
+        ],
+    })]
+    #[case(SubjectInfoAccess {
+        descriptors: vec![
+            AccessDescription {
+                access_method: ObjectIdentifier::from_str(SubjectInfoAccess::CA_REPOSITORY).unwrap(),
+                access_location: GeneralName::Uri("http://ca.example.com/repo".to_string()),
+            },
+            AccessDescription {
+                access_method: ObjectIdentifier::from_str(SubjectInfoAccess::TIME_STAMPING).unwrap(),
+                access_location: GeneralName::Uri("http://tsa.example.com".to_string()),
+            },
+        ],
+    })]
+    fn test_subject_info_access_encode_decode(#[case] original: SubjectInfoAccess) {
+        let encoded = original.encode().expect("encode failed");
+        let decoded: SubjectInfoAccess = encoded.decode().expect("decode failed");
+        assert_eq!(original, decoded);
+    }
+
+    #[test]
+    fn test_subject_info_access_parse_from_real_der() {
+        // SEQUENCE { SEQUENCE { OID 1.3.6.1.5.5.7.48.5, [6] "http://ca.example.com/repo" } }
+        let der_bytes = vec![
+            0x30, 0x28, // outer SEQUENCE, length 40
+            0x30, 0x26, // inner SEQUENCE, length 38
+            0x06, 0x08, 0x2B, 0x06, 0x01, 0x05, 0x05, 0x07, 0x30, 0x05, // OID caRepository
+            0x86, 0x1A, // [6] IMPLICIT, length 26
+            0x68, 0x74, 0x74, 0x70, 0x3A, 0x2F, 0x2F, 0x63, 0x61, 0x2E, 0x65, 0x78, 0x61, 0x6D,
+            0x70, 0x6C, 0x65, 0x2E, 0x63, 0x6F, 0x6D, 0x2F, 0x72, 0x65, 0x70,
+            0x6F, // "http://ca.example.com/repo"
+        ];
+        let octet_string = OctetString::from(der_bytes);
+
+        let extension = RawExtension::new(
+            ObjectIdentifier::from_str(SubjectInfoAccess::OID).unwrap(),
+            false,
+            octet_string,
+        );
+
+        let sia = extension
+            .parse::<SubjectInfoAccess>()
+            .expect("parse failed");
+
+        assert_eq!(sia.descriptors.len(), 1);
+        let desc = sia.descriptors.first().expect("descriptors empty");
+        assert_eq!(
+            desc.access_method.to_string(),
+            SubjectInfoAccess::CA_REPOSITORY
+        );
+        match &desc.access_location {
+            GeneralName::Uri(uri) => assert_eq!(uri, "http://ca.example.com/repo"),
+            _ => panic!("Expected Uri"),
+        }
+    }
+
+    #[test]
+    fn test_subject_info_access_der_bytes_roundtrip() {
+        // Same DER as test_subject_info_access_parse_from_real_der; verifies that
+        // parse → encode → der bytes produces the original input bytes exactly
+        // (RFC 5280 / X.690 DER canonical encoding).
+        let der_bytes = vec![
+            0x30, 0x28, 0x30, 0x26, 0x06, 0x08, 0x2B, 0x06, 0x01, 0x05, 0x05, 0x07, 0x30, 0x05,
+            0x86, 0x1A, 0x68, 0x74, 0x74, 0x70, 0x3A, 0x2F, 0x2F, 0x63, 0x61, 0x2E, 0x65, 0x78,
+            0x61, 0x6D, 0x70, 0x6C, 0x65, 0x2E, 0x63, 0x6F, 0x6D, 0x2F, 0x72, 0x65, 0x70, 0x6F,
+        ];
+
+        let octet_string = OctetString::from(der_bytes.clone());
+        let sia: SubjectInfoAccess = octet_string.decode().expect("decode failed");
+
+        let encoded_elem = sia.encode().expect("encode failed");
+        let tlv: tsumiki_der::Tlv = encoded_elem.encode().expect("tlv conversion failed");
+        let encoded_bytes: Vec<u8> = tlv.encode().expect("der encode failed");
+
+        assert_eq!(encoded_bytes, der_bytes);
+    }
+}

--- a/x509/src/lib.rs
+++ b/x509/src/lib.rs
@@ -383,23 +383,29 @@ impl fmt::Display for Certificate {
                 write!(f, "{}", aia)?;
             }
 
+            // Subject Info Access
+            if let Ok(Some(sia)) = self.extension::<extensions::SubjectInfoAccess>() {
+                write!(f, "{}", sia)?;
+            }
+
             // Display any other extensions not explicitly handled above
             let handled_oids = vec![
-                "2.5.29.14",         // SubjectKeyIdentifier
-                "2.5.29.35",         // AuthorityKeyIdentifier
-                "2.5.29.19",         // BasicConstraints
-                "2.5.29.15",         // KeyUsage
-                "2.5.29.37",         // ExtendedKeyUsage
-                "2.5.29.17",         // SubjectAltName
-                "2.5.29.18",         // IssuerAltName
-                "2.5.29.30",         // NameConstraints
-                "2.5.29.31",         // CRLDistributionPoints
-                "2.5.29.32",         // CertificatePolicies
-                "2.5.29.33",         // PolicyMappings
-                "2.5.29.36",         // PolicyConstraints
-                "2.5.29.46",         // FreshestCRL
-                "2.5.29.54",         // InhibitAnyPolicy
-                "1.3.6.1.5.5.7.1.1", // AuthorityInfoAccess
+                "2.5.29.14",          // SubjectKeyIdentifier
+                "2.5.29.35",          // AuthorityKeyIdentifier
+                "2.5.29.19",          // BasicConstraints
+                "2.5.29.15",          // KeyUsage
+                "2.5.29.37",          // ExtendedKeyUsage
+                "2.5.29.17",          // SubjectAltName
+                "2.5.29.18",          // IssuerAltName
+                "2.5.29.30",          // NameConstraints
+                "2.5.29.31",          // CRLDistributionPoints
+                "2.5.29.32",          // CertificatePolicies
+                "2.5.29.33",          // PolicyMappings
+                "2.5.29.36",          // PolicyConstraints
+                "2.5.29.46",          // FreshestCRL
+                "2.5.29.54",          // InhibitAnyPolicy
+                "1.3.6.1.5.5.7.1.1",  // AuthorityInfoAccess
+                "1.3.6.1.5.5.7.1.11", // SubjectInfoAccess
             ];
 
             if let Some(ref exts) = self.tbs_certificate.extensions {

--- a/x509/src/lib.rs
+++ b/x509/src/lib.rs
@@ -388,6 +388,11 @@ impl fmt::Display for Certificate {
                 write!(f, "{}", sia)?;
             }
 
+            // Subject Directory Attributes
+            if let Ok(Some(sda)) = self.extension::<extensions::SubjectDirectoryAttributes>() {
+                write!(f, "{}", sda)?;
+            }
+
             // Display any other extensions not explicitly handled above
             let handled_oids = vec![
                 "2.5.29.14",          // SubjectKeyIdentifier
@@ -406,6 +411,7 @@ impl fmt::Display for Certificate {
                 "2.5.29.54",          // InhibitAnyPolicy
                 "1.3.6.1.5.5.7.1.1",  // AuthorityInfoAccess
                 "1.3.6.1.5.5.7.1.11", // SubjectInfoAccess
+                "2.5.29.9",           // SubjectDirectoryAttributes
             ];
 
             if let Some(ref exts) = self.tbs_certificate.extensions {


### PR DESCRIPTION
- **Remove deprecated privateKeyUsagePeriod from oid_name()**
- **Add SubjectInfoAccess (RFC 5280 §4.2.2.2) extension**
- **Add SubjectDirectoryAttributes (RFC 5280 §4.2.1.8) extension**
